### PR TITLE
Use shared renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"],
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchCurrentVersion": "!/^0/",
-      "automerge": true
-    }
-  ]
+  "extends": ["github>ScottG489/renovate-config"]
 }


### PR DESCRIPTION
## Summary
- Replace inline renovate configuration with shared preset from `ScottG489/renovate-config`
- Remove duplicated rules (extends, packageRules, customManagers) that are now inherited from the shared config
- Keep only repo-specific configuration that isn't in the shared preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)